### PR TITLE
Add slash command support and gifting features

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ O bot carregará os arquivos JSON existentes (ou criará novos) e ficará online
 | `!historico [@user]` | Histórico recente de partidas do jogador. |
 | `!setcanal <tipo>` | Configura canais de fila, ranking, notificações e logs. |
 | `!loja`, `!comprar`, `!vender` | Interagem com a economia do bot. |
+| `!presentear @user <coins>` | Transfere coins para outro jogador. |
 | `!daily` | Resgata recompensa diária se o cooldown já expirou. |
+
+> Todos os comandos acima possuem versões _slash_ (`/fila`, `/perfil`, `/inventario`, `/top`, `/topvitorias`, `/topderrotas`, `/topstreak`, `/historico`, `/saldo`, `/loja`, `/comprar`, `/vender`, `/presentear`, `/daily`).
 
 ## 📝 Desenvolvimento
 - O código utiliza `discord.ext.commands` e comandos _slash_ via `discord.app_commands`.


### PR DESCRIPTION
## Summary
- add helper utilities to normalize player data, send responses, and reuse economy logic
- implement slash command equivalents for ranking, history, economy, and add a presentear/gift command plus updated embeds
- refresh help/README documentation to mention the new commands and slash availability

## Testing
- python -m compileall bot.py

------
https://chatgpt.com/codex/tasks/task_e_68dc0d491bf883269a891c2fa109a9a8